### PR TITLE
fix/fetch documentation input param

### DIFF
--- a/src/api/tools/repoHandlers/DefaultRepoHandler.ts
+++ b/src/api/tools/repoHandlers/DefaultRepoHandler.ts
@@ -30,7 +30,7 @@ class DefaultRepoHandler implements RepoHandler {
       {
         name: fetchToolName,
         description: fetchToolDescription,
-        paramsSchema: undefined,
+        paramsSchema: {},
         cb: async () => {
           return fetchDocumentation({ repoData, env, ctx });
         },


### PR DESCRIPTION
If `inputParams` is `undefined`, `parameters` is returning non valid object;
```
{
    "name": "fetch_langgraph_documentation",
    "description": "Fetch entire documentation file from GitHub repository: langchain-ai/langgraph. Useful for general questions. Always call this tool first if asked about langchain-ai/langgraph.",
    "parameters": {
        "type": "object"
    }
}
```

If `inputParams` is `{}`, `parameters` is returning correct empty object;
```
{
    "name": "fetch_langgraph_documentation",
    "description": "Fetch entire documentation file from GitHub repository: langchain-ai/langgraph. Useful for general questions. Always call this tool first if asked about langchain-ai/langgraph.",
    "parameters": {
        "type": "object",
        "properties": {},
        "additionalProperties": false,
        "$schema": "http://json-schema.org/draft-07/schema#"
    }
}
```