### PR TITLE
Add Augment Code to compatible MCP clients list

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Using GitMCP is easy! Simply follow these steps:
 
 Choose one of these URL formats depending on what you want to connect to:
 
-- For GitHub repositories: `gitmcp.io/{owner}/{repo}` 
+- For GitHub repositories: `gitmcp.io/{owner}/{repo}`
 - For GitHub Pages sites: `{owner}.gitmcp.io/{repo}`
 - For a generic tool that supports any repository (dynamic): `gitmcp.io/docs`
 
@@ -162,6 +162,17 @@ Plugin name: `gitmcp`
 SSE URL: `https://gitmcp.io/{owner}/{repo}`
 
 For more details on adding custom MCP servers to HighlightAI, refer to [the documentation](https://docs.highlightai.com/learn/developers/plugins/custom-plugins-setup).
+
+#### Connecting Augment Code
+
+1. Open Augment Code settings
+2. Navigate to the MCP section
+3. Add a new MCP server with the following details:
+
+Server name: `gitmcp`
+URL: `https://gitmcp.io/{owner}/{repo}`
+
+For more details on configuring MCP servers in Augment Code, visit [the Augment Code website](https://augmentcode.com/).
 
 > **Note:** Remember to replace `{owner}` and `{repo}` with the actual GitHub username/organization and repository name. You can also use the dynamic endpoint `https://gitmcp.io/docs` to allow your AI to access any repository on demand.
 
@@ -272,7 +283,7 @@ You can customize the badge's appearance with parameters:
 | Parameter | Description | Default | Example |
 |-----------|-------------|---------|---------|
 | `color` | Color for the badge value | `aquamarine` | `?color=green` |
-| `label` | Badge label | `GitMCP` | `Documentation` 
+| `label` | Badge label | `GitMCP` | `Documentation`
 
 Please reach out!
 

--- a/README.md
+++ b/README.md
@@ -169,10 +169,29 @@ For more details on adding custom MCP servers to HighlightAI, refer to [the docu
 2. Navigate to the MCP section
 3. Add a new MCP server with the following details:
 
-Server name: `gitmcp`
-URL: `https://gitmcp.io/{owner}/{repo}`
+Name the MCP server: `git-mcp Docs`
 
-For more details on configuring MCP servers in Augment Code, visit [the Augment Code website](https://augmentcode.com/).
+Use this command:
+```bash
+npx mcp-remote https://gitmcp.io/{owner}/{repo}
+```
+
+Or use the following configuration:
+```json
+{
+  "mcpServers": {
+    "git-mcp Docs": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://gitmcp.io/{owner}/{repo}"
+      ]
+    }
+  }
+}
+```
+
+For more details on configuring MCP servers in Augment Code, visit [the Augment Code documentation](https://docs.augmentcode.com/setup-augment/mcp).
 
 > **Note:** Remember to replace `{owner}` and `{repo}` with the actual GitHub username/organization and repository name. You can also use the dynamic endpoint `https://gitmcp.io/docs` to allow your AI to access any repository on demand.
 

--- a/app/components/content.tsx
+++ b/app/components/content.tsx
@@ -488,29 +488,49 @@ export default function Content({
                   </ul>
 
                   <p className="text-sm text-slate-700 mb-4">
-                    Enter this as your server name:{" "}
+                    Name the MCP server:{" "}
                     <code className="bg-slate-200 px-2 py-1 rounded text-blue-700 break-words block my-3">
-                      {serverName}
+                      git-mcp Docs
                     </code>
                   </p>
 
                   <p className="text-sm text-slate-700 mb-4">
-                    Enter this as the server URL:{" "}
+                    Use this command:{" "}
                     <code className="bg-slate-200 px-2 py-1 rounded text-blue-700 break-words block my-3">
-                      {url}
+                      npx mcp-remote ${url}
                     </code>
                   </p>
+
+                  <p className="text-sm text-slate-700 mb-4">
+                    Or use the following configuration:{" "}
+                  </p>
+
+                  <CodeExample
+                    code={`{
+  "mcpServers": {
+    "git-mcp Docs": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "${url}"
+      ]
+    }
+  }
+}`}
+                    id="augment-code"
+                    name="Augment Code"
+                  />
 
                   <p className="text-sm text-slate-700 mt-4">
                     For more details on configuring MCP servers in Augment Code,
                     visit{" "}
                     <a
-                      href="https://augmentcode.com/"
+                      href="https://docs.augmentcode.com/setup-augment/mcp"
                       target="_blank"
                       rel="noopener noreferrer"
                       className="text-blue-600 hover:text-blue-800"
                     >
-                      the Augment Code website
+                      the Augment Code documentation
                     </a>
                     .
                   </p>
@@ -520,98 +540,102 @@ export default function Content({
           </div>
         </div>
 
-        <div className="mt-8 flex flex-wrap items-center justify-center gap-4 sm:gap-0 sm:space-x-8">
-          <a
-            href="https://claude.ai"
-            className="text-blue-600 hover:text-blue-800 flex items-center transition-colors"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <img
-              src={getToolFaviconUrl("Claude Desktop")}
-              alt="Claude"
-              className="h-6 w-6 mr-2"
-            />
-            Claude
-          </a>
-          <a
-            href="https://cursor.com"
-            className="text-blue-600 hover:text-blue-800 flex items-center transition-colors"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <img
-              src={getToolFaviconUrl("Cursor")}
-              alt="Cursor"
-              className="h-6 w-6 mr-2"
-            />
-            Cursor
-          </a>
-          <a
-            href="https://codeium.com/windsurf"
-            className="text-blue-600 hover:text-blue-800 flex items-center transition-colors"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <img
-              src={getToolFaviconUrl("Windsurf")}
-              alt="Windsurf"
-              className="h-6 w-6 mr-2"
-            />
-            Windsurf
-          </a>
-          <a
-            href="https://code.visualstudio.com/"
-            className="text-blue-600 hover:text-blue-800 flex items-center transition-colors"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <img
-              src="https://code.visualstudio.com/assets/favicon.ico"
-              alt="VSCode"
-              className="h-6 w-6 mr-2"
-            />
-            VSCode
-          </a>
-          <a
-            href="https://cline.tools"
-            className="text-blue-600 hover:text-blue-800 flex items-center transition-colors"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <img
-              src={getToolFaviconUrl("Cline")}
-              alt="Cline"
-              className="h-6 w-6 mr-2"
-            />
-            Cline
-          </a>
-          <a
-            href="https://highlightai.com"
-            className="text-blue-600 hover:text-blue-800 flex items-center transition-colors"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <img
-              src={getToolFaviconUrl("Highlight AI")}
-              alt="Highlight AI"
-              className="h-6 w-6 mr-2"
-            />
-            Highlight AI
-          </a>
-          <a
-            href="https://augmentcode.com"
-            className="text-blue-600 hover:text-blue-800 flex items-center transition-colors"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <img
-              src={getToolFaviconUrl("Augment Code")}
-              alt="Augment Code"
-              className="h-6 w-6 mr-2"
-            />
-            Augment Code
-          </a>
+        <div className="mt-8 flex flex-col items-center justify-center">
+          <div className="flex justify-center space-x-8 mb-6">
+            <a
+              href="https://claude.ai"
+              className="text-blue-600 hover:text-blue-800 flex items-center transition-colors"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <img
+                src={getToolFaviconUrl("Claude Desktop")}
+                alt="Claude"
+                className="h-6 w-6 mr-2"
+              />
+              Claude
+            </a>
+            <a
+              href="https://cursor.com"
+              className="text-blue-600 hover:text-blue-800 flex items-center transition-colors"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <img
+                src={getToolFaviconUrl("Cursor")}
+                alt="Cursor"
+                className="h-6 w-6 mr-2"
+              />
+              Cursor
+            </a>
+            <a
+              href="https://codeium.com/windsurf"
+              className="text-blue-600 hover:text-blue-800 flex items-center transition-colors"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <img
+                src={getToolFaviconUrl("Windsurf")}
+                alt="Windsurf"
+                className="h-6 w-6 mr-2"
+              />
+              Windsurf
+            </a>
+            <a
+              href="https://code.visualstudio.com/"
+              className="text-blue-600 hover:text-blue-800 flex items-center transition-colors"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <img
+                src="https://code.visualstudio.com/assets/favicon.ico"
+                alt="VSCode"
+                className="h-6 w-6 mr-2"
+              />
+              VSCode
+            </a>
+          </div>
+          <div className="flex justify-center space-x-8">
+            <a
+              href="https://cline.tools"
+              className="text-blue-600 hover:text-blue-800 flex items-center transition-colors"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <img
+                src={getToolFaviconUrl("Cline")}
+                alt="Cline"
+                className="h-6 w-6 mr-2"
+              />
+              Cline
+            </a>
+            <a
+              href="https://highlightai.com"
+              className="text-blue-600 hover:text-blue-800 flex items-center transition-colors"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <img
+                src={getToolFaviconUrl("Highlight AI")}
+                alt="Highlight AI"
+                className="h-6 w-6 mr-2"
+              />
+              Highlight AI
+            </a>
+            <a
+              href="https://augmentcode.com"
+              className="text-blue-600 hover:text-blue-800 flex items-center transition-colors"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <img
+                src={getToolFaviconUrl("Augment Code")}
+                alt="Augment Code"
+                className="h-6 w-6 mr-2"
+              />
+              Augment Code
+            </a>
+          </div>
         </div>
       </div>
     </div>

--- a/app/components/content.tsx
+++ b/app/components/content.tsx
@@ -107,6 +107,8 @@ export default function Content({
         return "https://cline.bot/assets/icons/favicon-256x256.png";
       case "Highlight AI":
         return "https://highlightai.com/favicon.ico";
+      case "Augment Code":
+        return "https://cdn.prod.website-files.com/66d76c2202b335e39ad2b5e8/66f302d663108ca67c19ddbc_Favicon.png";
       default:
         return "https://codeium.com/favicon.ico";
     }
@@ -238,6 +240,7 @@ export default function Content({
                 "VSCode",
                 "Cline",
                 "Highlight AI",
+                "Augment Code",
               ].map((tab, index) => (
                 <button
                   key={tab}
@@ -474,6 +477,46 @@ export default function Content({
                 </div>
               </div>
             </div>
+
+            <div id="tab-augment-code" className="tab-content hidden">
+              <div className="bg-slate-50 p-3 sm:p-4 rounded-md border border-slate-200">
+                <div className="p-4">
+                  <ul className="text-sm text-slate-700 mb-4 list-disc pl-5 space-y-2">
+                    <li>Open Augment Code settings</li>
+                    <li>Navigate to the MCP section</li>
+                    <li>Add a new MCP server with the following details</li>
+                  </ul>
+
+                  <p className="text-sm text-slate-700 mb-4">
+                    Enter this as your server name:{" "}
+                    <code className="bg-slate-200 px-2 py-1 rounded text-blue-700 break-words block my-3">
+                      {serverName}
+                    </code>
+                  </p>
+
+                  <p className="text-sm text-slate-700 mb-4">
+                    Enter this as the server URL:{" "}
+                    <code className="bg-slate-200 px-2 py-1 rounded text-blue-700 break-words block my-3">
+                      {url}
+                    </code>
+                  </p>
+
+                  <p className="text-sm text-slate-700 mt-4">
+                    For more details on configuring MCP servers in Augment Code,
+                    visit{" "}
+                    <a
+                      href="https://augmentcode.com/"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-600 hover:text-blue-800"
+                    >
+                      the Augment Code website
+                    </a>
+                    .
+                  </p>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
 
@@ -555,6 +598,19 @@ export default function Content({
               className="h-6 w-6 mr-2"
             />
             Highlight AI
+          </a>
+          <a
+            href="https://augmentcode.com"
+            className="text-blue-600 hover:text-blue-800 flex items-center transition-colors"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <img
+              src={getToolFaviconUrl("Augment Code")}
+              alt="Augment Code"
+              className="h-6 w-6 mr-2"
+            />
+            Augment Code
           </a>
         </div>
       </div>

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -531,6 +531,26 @@ export default function Home() {
                 </span>
               </a>
             </div>
+
+            <div className="flex flex-col items-center">
+              <a
+                href="https://augmentcode.com/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group hover:opacity-90 transition-opacity flex flex-col items-center"
+              >
+                <div className="w-16 h-16 sm:w-20 sm:h-20 bg-gradient-to-br from-gray-700 to-gray-800 rounded-xl shadow-lg flex items-center justify-center mb-3 group-hover:from-gray-650 group-hover:to-gray-750 transition-all">
+                  <img
+                    src="https://augmentcode.com/favicon.ico"
+                    alt="Augment Code"
+                    className="h-8 w-8 sm:h-10 sm:w-10"
+                  />
+                </div>
+                <span className="text-gray-200 text-base sm:text-lg font-medium">
+                  Augment Code
+                </span>
+              </a>
+            </div>
           </div>
         </div>
       </section>

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -541,7 +541,7 @@ export default function Home() {
               >
                 <div className="w-16 h-16 sm:w-20 sm:h-20 bg-gradient-to-br from-gray-700 to-gray-800 rounded-xl shadow-lg flex items-center justify-center mb-3 group-hover:from-gray-650 group-hover:to-gray-750 transition-all">
                   <img
-                    src="https://augmentcode.com/favicon.ico"
+                    src="https://cdn.prod.website-files.com/66d76c2202b335e39ad2b5e8/66f302d663108ca67c19ddbc_Favicon.png"
                     alt="Augment Code"
                     className="h-8 w-8 sm:h-10 sm:w-10"
                   />


### PR DESCRIPTION
Hi! I work at [Augment Code](https://augmentcode.com/) and would like to add Augment Code to the list of compatible MCP clients/IDEs in the homepage.

This PR adds Augment Code as an additional option in the 'Compatible With' section alongside Claude, Cursor, Windsurf, VSCode, Cline, and Highlight AI.

## Changes Made:
- Added Augment Code entry to the AI tools grid in app/routes/_index.tsx
- Follows the same visual pattern as existing entries (icon container with gradient background, tool name below)
- Links to https://augmentcode.com/ when clicked
- Uses the official Augment Code logo
- Maintains responsive design and hover effects consistent with other entries

## Testing:
- Verified the entry displays correctly in the development environment
- Confirmed the link works properly
- Ensured visual consistency with existing entries

Augment Code is an AI-powered coding assistant that supports MCP, making it a natural fit for this list of compatible tools.

Thanks for considering this addition