### PR TITLE
Fix Cline MCP configuration by adding required transportType field

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ Update your Cline configuration file at `~/Library/Application Support/Code/User
        "gitmcp": {
          "url": "https://gitmcp.io/{owner}/{repo}",
          "disabled": false,
-         "autoApprove": []
+         "autoApprove": [],
+         "transportType": "sse"
        }
      }
    }

--- a/app/components/content.tsx
+++ b/app/components/content.tsx
@@ -399,7 +399,8 @@ export default function Content({
     "${serverName}": {
       "url": "${url}",
       "disabled": false,
-      "autoApprove": []
+      "autoApprove": [],
+      "transportType": "sse"
     }
   }
 }`}


### PR DESCRIPTION
## Problem
Current versions of Cline strictly validate MCP server configurations and require a `transportType` field that was missing from our configuration. Users attempting to connect Cline to GitMCP receive an "invalid mcp settings schema" error.

## Solution
This PR adds the required `transportType: "sse"` field to the Cline MCP configuration in both:
1. The README.md documentation
2. The app/components/content.tsx file that generates configuration code examples

## Testing
Tested with Cline v3.16.3 in VS Code v1.99.3:
- Without the `transportType` field: "invalid mcp settings schema" error
- With the `transportType: "sse"` field: works correctly

## References
- Cline issue [#3705](https://github.com/cline/cline/issues/3705) - Schema validation errors requiring transportType field
- Cline issue [#1937](https://github.com/cline/cline/issues/1937) - Original issue adding SSE transport support
- Cline PR [#3700](https://github.com/cline/cline/pull/3700) - MCP hub type fixes in v3.16.3 release