### PR TITLE
fix: sanitize error responses to prevent stack trace exposure

### DIFF
--- a/app/routes/api.chat.ts
+++ b/app/routes/api.chat.ts
@@ -196,10 +196,10 @@ export async function action({
           );
         }
       }
-      const message =
-        error instanceof Error ? error.message : "An error occurred.";
-      console.error(error);
-      return message;
+      // Log the full error server-side for debugging, but return a generic
+      // message to the client to avoid leaking stack traces or internal paths.
+      console.error("Chat stream error:", error);
+      return "An unexpected error occurred. Please try again later.";
     },
   });
 }

--- a/src/api/test-setup.ts
+++ b/src/api/test-setup.ts
@@ -56,15 +56,11 @@ export async function handleR2TestSetup(
       );
       console.log(`Uploaded hardcoded content to ${file.bucketPath} in R2`);
     } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
       console.error(
         `Error uploading hardcoded content to ${file.bucketPath} in R2:`,
-        errorMessage,
+        error,
       );
-      results.push(
-        `Failed to upload hardcoded content to ${file.bucketPath}: ${errorMessage}`,
-      );
+      results.push(`Failed to upload hardcoded content to ${file.bucketPath}`);
       errors++;
     }
   }

--- a/src/api/tools/commonTools.ts
+++ b/src/api/tools/commonTools.ts
@@ -695,13 +695,13 @@ export async function searchRepositoryCode({
       },
     };
   } catch (error) {
-    console.error(`Error in searchRepositoryCode: ${error}`);
+    console.error("Error in searchRepositoryCode:", error);
     return {
       searchQuery: query,
       content: [
         {
           type: "text" as const,
-          text: `### Code Search Results for: "${query}"\n\nAn error occurred while searching code: ${error}`,
+          text: `### Code Search Results for: "${query}"\n\nAn error occurred while searching code. Please try again later.`,
         },
       ],
     };
@@ -766,14 +766,14 @@ export async function fetchUrlContent({ url, env }: { url: string; env: Env }) {
       ],
     };
   } catch (error) {
-    console.error(`Error fetching ${url}: ${error}`);
+    console.error(`Error fetching ${url}:`, error);
     return {
       url,
       status: "error",
       content: [
         {
           type: "text" as const,
-          text: `Error fetching content from ${url}: ${error}`,
+          text: `Error fetching content from ${url}. Please try again later.`,
         },
       ],
     };


### PR DESCRIPTION
## Summary

Addresses finding #2 from #218 (ASF-2026-2047): error messages were returned directly to clients without sanitization, potentially revealing internal paths, stack traces, and application structure.

### Changes

- **`app/routes/api.chat.ts`**: The `getErrorMessage` fallback in `toDataStreamResponse` previously returned the raw `error.message` to the client. Now returns a generic `"An unexpected error occurred. Please try again later."` while logging the full error server-side via `console.error()`.

- **`src/api/tools/commonTools.ts`** (`searchRepositoryCode`): Error catch block was interpolating the raw error object into user-facing response text (`An error occurred while searching code: ${error}`). Replaced with a static message; detailed error is logged server-side.

- **`src/api/tools/commonTools.ts`** (`fetchUrlContent`): Same pattern — raw error was embedded in the response text. Now returns a generic message.

- **`src/api/test-setup.ts`** (`handleR2TestSetup`): R2 upload failure results included `error.message` in the JSON response body. Removed the error detail from the response; it is now only logged server-side.

### Approach

The fix follows a consistent pattern across all four locations:
1. Log the full error server-side (`console.error`) for debugging
2. Return a generic, safe message to the client

Specific known-safe error messages (rate limit, API key missing) in `api.chat.ts` are preserved as-is since they contain no internal details.

### Testing

- `npx tsc --noEmit` passes with no errors
- Pre-commit hooks (lint-staged / prettier) pass

Fixes #218

## Test plan

- [ ] Trigger a chat error (e.g., invalid API key) and verify the response contains a generic message, not a stack trace
- [ ] Trigger a code search failure and verify no internal error details leak
- [ ] Trigger a URL fetch error and verify sanitized response
- [ ] Verify server logs still contain the full error for debugging