### PR TITLE
Add Codex CLI plugin manifest

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,29 @@
+{
+  "name": "git-mcp",
+  "version": "0.1.0",
+  "description": "GitMCP plugin for Codex - eliminate code hallucinations with up-to-date GitHub project docs",
+  "author": {
+    "name": "idosal",
+    "url": "https://github.com/idosal"
+  },
+  "homepage": "https://gitmcp.io",
+  "repository": "https://github.com/idosal/git-mcp",
+  "license": "Apache-2.0",
+  "keywords": [
+    "mcp",
+    "git",
+    "github",
+    "documentation",
+    "reverse-engineering"
+  ],
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "GitMCP",
+    "shortDescription": "Access up-to-date GitHub project docs and code via MCP",
+    "longDescription": "GitMCP is a free, open-source remote MCP server that transforms any GitHub project into a documentation hub. Enables Codex to access current docs and source code, eliminating code hallucinations.",
+    "developerName": "idosal",
+    "category": "Productivity",
+    "websiteURL": "https://gitmcp.io"
+  },
+  "skills": "./skills/"
+}

--- a/.github/workflows/plugin-quality-gate.yml
+++ b/.github/workflows/plugin-quality-gate.yml
@@ -1,0 +1,20 @@
+name: Plugin Quality Gate
+
+on:
+  pull_request:
+    paths:
+      - ".codex-plugin/**"
+      - "skills/**"
+      - ".mcp.json"
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Codex plugin quality gate
+        uses: hashgraph-online/hol-codex-plugin-scanner-action@v1
+        with:
+          plugin_dir: "."
+          min_score: 80
+          fail_on_severity: high

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "gitmcp": {
+      "type": "url",
+      "url": "https://gitmcp.io/docs"
+    }
+  }
+}

--- a/skills/git-mcp/SKILL.md
+++ b/skills/git-mcp/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: git-mcp
+description: Use GitMCP to access up-to-date GitHub project documentation and source code, eliminating code hallucinations.
+---
+
+# GitMCP for Codex
+
+Access up-to-date documentation and source code from any GitHub project through the GitMCP remote MCP server.
+
+## When to use
+
+- You need current API docs, code examples, or usage patterns from a GitHub repo
+- The user references a library or framework you want accurate information about
+- You need to verify your knowledge against the actual source code
+
+## Available servers
+
+- **gitmcp (generic):** `https://gitmcp.io/docs` - AI picks the repo from context
+- **Per-repo:** `https://gitmcp.io/{owner}/{repo}` - Scoped to a specific repository
+
+## Tips
+
+- For common libraries, the generic server works well
+- For lesser-known or private repos, use the per-repo URL
+- Combine with file reading for hybrid local + remote research


### PR DESCRIPTION
Adds a `.codex-plugin/plugin.json` manifest so GitMCP can be installed as a Codex CLI plugin.

Since GitMCP is a remote MCP server, the plugin wraps it via a `.mcp.json` reference to `https://gitmcp.io/docs`. No local build step needed.

**What this adds:**
- `.codex-plugin/plugin.json` — Plugin manifest with metadata
- `.mcp.json` — Remote MCP server reference (gitmcp.io)
- `skills/git-mcp/SKILL.md` — Usage guide for Codex

**Related resources:**
- [awesome-codex-plugins](https://github.com/internet-dot/awesome-codex-plugins) — Curated directory of Codex plugins (open a PR to get listed!)
- [codex-plugin-scanner](https://github.com/hashgraph-online/ai-plugin-scanner) — Security and quality scanner for Codex plugins (scores 0-100, CI action available)